### PR TITLE
Add support for srv urls in MongoDB

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ exports = module.exports = class Connection {
 
         const settings = Hoek.applyToDefaults(defaults, options);
 
-        settings.uri = settings.uri.replace(/(mongodb:\/\/[^\/]*)([^\?]*)(.*)/,`$1/${settings.partition}$3`);
+        settings.uri = settings.uri.replace(/(mongodb(?:\+srv)?:\/\/[^\/]*)([^\?]*)(.*)/,`$1/${settings.partition}$3`);
 
         return settings;
     }


### PR DESCRIPTION
This PR adds supports for MongoDB string connections with +srv

Example: mongodb+srv://mongosrv/?authSource=admin